### PR TITLE
Build PRs as basic sanity check

### DIFF
--- a/.github/workflows/02-pr-checks.yml
+++ b/.github/workflows/02-pr-checks.yml
@@ -1,0 +1,22 @@
+name: PR checks
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install DJGPP
+        run: |
+          wget -P /tmp https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
+          echo "8464f17017d6ab1b2bb2df4ed82357b5bf692e6e2b7fee37e315638f3d505f00  /tmp/djgpp-linux64-gcc1220.tar.bz2" | shasum -a 256 --check
+          tar -xf /tmp/djgpp-linux64-gcc1220.tar.bz2 -C /opt
+          rm /tmp/djgpp-linux64-gcc1220.tar.bz2
+      - name: Build project
+        run: |
+          . /opt/djgpp/setenv
+          make
+          i586-pc-msdosdjgpp-objdump -x output/sbemu.exe


### PR DESCRIPTION
It's useful to build the source from a pull request to make sure we don't merge anything that doesn't even build.