### PR TITLE
Use preinstalled djgpp image in workflows

### DIFF
--- a/.github/workflows/01-build-and-release.yml
+++ b/.github/workflows/01-build-and-release.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/src
           test -f main.c
-          make
+          make CC=gcc CXX=g++
           test -f output/sbemu.exe
       - name: Build FreeDOS SBEMU USB image
         run: |

--- a/.github/workflows/01-build-and-release.yml
+++ b/.github/workflows/01-build-and-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - set-up-cicd
+      - use-preinstalled-djgpp-image-in-workflows
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/01-build-and-release.yml
+++ b/.github/workflows/01-build-and-release.yml
@@ -9,23 +9,16 @@ permissions:
   contents: write
 jobs:
   release-job:
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/volkertb/debian-djgpp:v0.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           path: src
-      - name: Install DJGPP
-        run: |
-          wget -P /tmp https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
-          echo "8464f17017d6ab1b2bb2df4ed82357b5bf692e6e2b7fee37e315638f3d505f00  /tmp/djgpp-linux64-gcc1220.tar.bz2" | shasum -a 256 --check
-          tar -xf /tmp/djgpp-linux64-gcc1220.tar.bz2 -C /opt
-          rm /tmp/djgpp-linux64-gcc1220.tar.bz2
       - name: Build project
         run: |
           cd $GITHUB_WORKSPACE/src
           test -f main.c
-          . /opt/djgpp/setenv
           make
           test -f output/sbemu.exe
       - name: Build FreeDOS SBEMU USB image

--- a/.github/workflows/01-build-and-release.yml
+++ b/.github/workflows/01-build-and-release.yml
@@ -25,7 +25,6 @@ jobs:
           test -f output/sbemu.exe
       - name: Build FreeDOS SBEMU USB image
         run: |
-          shellcheck $GITHUB_WORKSPACE/src/scripts/build-release-artifacts.sh
           $GITHUB_WORKSPACE/src/scripts/build-release-artifacts.sh $GITHUB_WORKSPACE/src/output/sbemu.exe $GITHUB_WORKSPACE/
       - name: Generate release tag
         id: tag

--- a/.github/workflows/01-build-and-release.yml
+++ b/.github/workflows/01-build-and-release.yml
@@ -9,7 +9,9 @@ permissions:
   contents: write
 jobs:
   release-job:
-    runs-on: ghcr.io/volkertb/debian-djgpp:v0.2
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/volkertb/debian-djgpp:v0.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/02-pr-checks.yml
+++ b/.github/workflows/02-pr-checks.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - main
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: shellcheck build-release-artifacts.sh
+        run: |
+          shellcheck scripts/build-release-artifacts.sh
   build:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/02-pr-checks.yml
+++ b/.github/workflows/02-pr-checks.yml
@@ -13,5 +13,5 @@ jobs:
         uses: actions/checkout@v3
       - name: Build project
         run: |
-          make
-          i586-pc-msdosdjgpp-objdump -x output/sbemu.exe
+          make CC=gcc CXX=g++
+          objdump -x output/sbemu.exe

--- a/.github/workflows/02-pr-checks.yml
+++ b/.github/workflows/02-pr-checks.yml
@@ -5,18 +5,11 @@ on:
       - main
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/volkertb/debian-djgpp:v0.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Install DJGPP
-        run: |
-          wget -P /tmp https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
-          echo "8464f17017d6ab1b2bb2df4ed82357b5bf692e6e2b7fee37e315638f3d505f00  /tmp/djgpp-linux64-gcc1220.tar.bz2" | shasum -a 256 --check
-          tar -xf /tmp/djgpp-linux64-gcc1220.tar.bz2 -C /opt
-          rm /tmp/djgpp-linux64-gcc1220.tar.bz2
       - name: Build project
         run: |
-          . /opt/djgpp/setenv
           make
           i586-pc-msdosdjgpp-objdump -x output/sbemu.exe

--- a/.github/workflows/02-pr-checks.yml
+++ b/.github/workflows/02-pr-checks.yml
@@ -5,7 +5,9 @@ on:
       - main
 jobs:
   build:
-    runs-on: ghcr.io/volkertb/debian-djgpp:v0.2
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/volkertb/debian-djgpp:v0.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Hopefully this will speed up the pipelines, since DJGPP doesn't have to be downloaded and installed in each pipeline when they are run on this image that already includes a DJGPP installation.

Also, using specific image versions should make the builds fully reproducible.

For the project that builds and publishes this image, see https://github.com/volkertb/debian-djgpp