### PR TITLE
pcibios_enable_memmap_set_master_all, fix PCI command register width

### DIFF
--- a/mpxplay/au_cards/pcibios.c
+++ b/mpxplay/au_cards/pcibios.c
@@ -317,9 +317,9 @@ void pcibios_WriteConfig_Dword(pci_config_s * ppkey, uint16_t wAdr, uint32_t dwD
 void pcibios_set_master(pci_config_s *ppkey)
 {
  unsigned int cmd;
- cmd=pcibios_ReadConfig_Byte(ppkey, PCIR_PCICMD);
+ cmd=pcibios_ReadConfig_Word(ppkey, PCIR_PCICMD);
  cmd|=0x01|0x04;
- pcibios_WriteConfig_Byte(ppkey, PCIR_PCICMD, cmd);
+ pcibios_WriteConfig_Word(ppkey, PCIR_PCICMD, cmd);
 }
 
 void pcibios_enable_memmap_set_master(pci_config_s *ppkey)
@@ -328,15 +328,23 @@ void pcibios_enable_memmap_set_master(pci_config_s *ppkey)
  cmd=pcibios_ReadConfig_Byte(ppkey, PCIR_PCICMD);
  cmd&=~0x01;     // disable io-port mapping
  cmd|=0x02|0x04; // enable memory mapping and set master
- pcibios_WriteConfig_Byte(ppkey, PCIR_PCICMD, cmd);
+ pcibios_WriteConfig_Word(ppkey, PCIR_PCICMD, cmd);
+}
+
+void pcibios_enable_memmap_set_master_all(pci_config_s *ppkey)
+{
+ unsigned int cmd;
+ cmd=pcibios_ReadConfig_Word(ppkey, PCIR_PCICMD);
+ cmd|=0x01|0x02|0x04; // enable io-port mapping and memory mapping and set master
+ pcibios_WriteConfig_Word(ppkey, PCIR_PCICMD, cmd);
 }
 
 void pcibios_enable_interrupt(pci_config_s* ppkey)
 {
  unsigned int cmd;
- cmd=pcibios_ReadConfig_Byte(ppkey, PCIR_PCICMD);
+ cmd=pcibios_ReadConfig_Word(ppkey, PCIR_PCICMD);
  cmd &= ~(1<<10);
- pcibios_WriteConfig_Byte(ppkey, PCIR_PCICMD, cmd);
+ pcibios_WriteConfig_Word(ppkey, PCIR_PCICMD, cmd);
 }
 
 typedef struct

--- a/mpxplay/au_cards/pcibios.c
+++ b/mpxplay/au_cards/pcibios.c
@@ -325,7 +325,7 @@ void pcibios_set_master(pci_config_s *ppkey)
 void pcibios_enable_memmap_set_master(pci_config_s *ppkey)
 {
  unsigned int cmd;
- cmd=pcibios_ReadConfig_Byte(ppkey, PCIR_PCICMD);
+ cmd=pcibios_ReadConfig_Word(ppkey, PCIR_PCICMD);
  cmd&=~0x01;     // disable io-port mapping
  cmd|=0x02|0x04; // enable memory mapping and set master
  pcibios_WriteConfig_Word(ppkey, PCIR_PCICMD, cmd);

--- a/mpxplay/au_cards/pcibios.h
+++ b/mpxplay/au_cards/pcibios.h
@@ -116,6 +116,7 @@ void     pcibios_WriteConfig_Dword(pci_config_s *, uint16_t, uint32_t);
 void     pcibios_set_master(pci_config_s *);
 void     pcibios_enable_interrupt(pci_config_s*);
 void     pcibios_enable_memmap_set_master(pci_config_s *);
+void     pcibios_enable_memmap_set_master_all(pci_config_s *);
 
 uint8_t  pcibios_AssignIRQ(pci_config_s*); //try to assign IRQ from PCI IRQ routing options.
 

--- a/sbemu/serial.c
+++ b/sbemu/serial.c
@@ -73,7 +73,7 @@ ser_setup(int stype, unsigned int sdev)
 
     if (iobase == 0) {
         if (sdev != 0) {
-            printf("Invalid COM port %d", sdev);
+            printf("Invalid COM port %d\n", sdev);
             return 1;
         } else {
             return 0;


### PR DESCRIPTION
Is it OK to change all byte reads/writes to 16 bit word read/writes?
Maybe there is some hardware that doesn't work one byte at a time?

Also, I think pcibios_enable_memmap_set_master_all (new function) is needed for some cards like YMF7xx.