### PR TITLE
Add /SCFM and /SCMPU options, to select which cards to use for FM/MPU

### DIFF
--- a/main.c
+++ b/main.c
@@ -37,7 +37,9 @@ PROGNAME = "SBEMU";
 #define MAIN_TSR_INT 0x2D   //AMIS multiplex. TODO: 0x2F?
 #define MAIN_TSR_INTSTART_ID 0x01 //start id
 
-mpxplay_audioout_info_s aui = {0};
+static mpxplay_audioout_info_s aui = {0};
+static mpxplay_audioout_info_s fm_aui = {0};
+static mpxplay_audioout_info_s mpu401_aui = {0};
 
 #define MAIN_PCM_SAMPLESIZE 16384
 
@@ -74,61 +76,52 @@ static const char MAIN_ISR_DOSID_String[] = "Crazii  SBEMU   Sound Blaster emula
 static void MAIN_TSR_InstallationCheck();
 static void MAIN_TSR_Interrupt();
 
-uint16_t main_hw_fmport = 0;
-#define hw_fm_outb(reg,data) outp(main_hw_fmport+reg,data)
-#define hw_fm_inb(reg) inp(main_hw_fmport+reg)
-
-uint16_t main_hw_mpuport = 0;
-#define hw_mpu_outb(reg,data) outp(main_hw_mpuport+reg,data)
-#define hw_mpu_inb(reg) inp(main_hw_mpuport+reg)
+#define HW_FM_HANDLER(n) do {\
+  if (fm_aui.fm) {                                                      \
+    if (out) {                                                          \
+      if (fm_aui.card_handler->card_fm_write) {                         \
+        fm_aui.card_handler->card_fm_write(&fm_aui, n, (uint8_t)(val & 0xff)); \
+        return val;                                                     \
+      }                                                                 \
+    } else {                                                            \
+      if (fm_aui.card_handler->card_fm_read)                            \
+        return fm_aui.card_handler->card_fm_read(&fm_aui, n);              \
+    }                                                                   \
+    return 0;                                                           \
+  } } while (0)
 
 static uint32_t MAIN_OPL3_388(uint32_t port, uint32_t val, uint32_t out)
 {
-  if (main_hw_fmport) {
-    if (out) {
-      hw_fm_outb(0, val & 0xff);
-      return val;
-    } else {
-      return hw_fm_inb(0);
-    }
-  }
   return out ? OPL3EMU_PrimaryWriteIndex(val) : OPL3EMU_PrimaryRead(val);
 }
 static uint32_t MAIN_OPL3_389(uint32_t port, uint32_t val, uint32_t out)
 {
-  if (main_hw_fmport) {
-    if (out) {
-      hw_fm_outb(1, val & 0xff);
-      return val;
-    } else {
-      return hw_fm_inb(1);
-    }
-  }
   return out ? OPL3EMU_PrimaryWriteData(val) : OPL3EMU_PrimaryRead(val);
 }
 static uint32_t MAIN_OPL3_38A(uint32_t port, uint32_t val, uint32_t out)
 {
-  if (main_hw_fmport) {
-    if (out) {
-      hw_fm_outb(2, val & 0xff);
-      return val;
-    } else {
-      return hw_fm_inb(2);
-    }
-  }
   return out ? OPL3EMU_SecondaryWriteIndex(val) : OPL3EMU_SecondaryRead(val);
 }
 static uint32_t MAIN_OPL3_38B(uint32_t port, uint32_t val, uint32_t out)
 {
-  if (main_hw_fmport) {
-    if (out) {
-      hw_fm_outb(3, val & 0xff);
-      return val;
-    } else {
-      return hw_fm_inb(3);
-    }
-  }
   return out ? OPL3EMU_SecondaryWriteData(val) : OPL3EMU_SecondaryRead(val);
+}
+
+static uint32_t MAIN_HW_OPL3_388(uint32_t port, uint32_t val, uint32_t out)
+{
+  HW_FM_HANDLER(0);
+}
+static uint32_t MAIN_HW_OPL3_389(uint32_t port, uint32_t val, uint32_t out)
+{
+  HW_FM_HANDLER(1);
+}
+static uint32_t MAIN_HW_OPL3_38A(uint32_t port, uint32_t val, uint32_t out)
+{
+  HW_FM_HANDLER(2);
+}
+static uint32_t MAIN_HW_OPL3_38B(uint32_t port, uint32_t val, uint32_t out)
+{
+  HW_FM_HANDLER(3);
 }
 
 static uint32_t MAIN_DMA(uint32_t port, uint32_t val, uint32_t out)
@@ -197,16 +190,14 @@ static uint32_t MAIN_MPU_330(uint32_t port, uint32_t val, uint32_t out)
   }
 #endif
   if (out) {
-    if (main_hw_mpuport) {
-      hw_mpu_outb(0, (unsigned char)(val & 0xff));
-    }
+    if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_write)
+      mpu401_aui.card_handler->card_mpu401_write(&mpu401_aui, 0, (uint8_t)(val & 0xff));
     ser_putbyte((int)(val & 0xff));
     return 0;
   } else {
     uint8_t val, hwval;
-    if (main_hw_mpuport) {
-      hwval = hw_mpu_inb(0);
-    }
+    if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_read)
+      hwval = mpu401_aui.card_handler->card_mpu401_read(&mpu401_aui, 0);
     if (mpu_state == 1) {
       mpu_state = 0;
       val = 0xfe;
@@ -216,10 +207,10 @@ static uint32_t MAIN_MPU_330(uint32_t port, uint32_t val, uint32_t out)
     } else {
       val = 0;
     }
-    if (main_hw_mpuport) {
-      val = hwval;
-    }
-    return val;
+    if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_read)
+      return hwval;
+    else
+      return val;
   }
 }
 static uint32_t MAIN_MPU_331(uint32_t port, uint32_t val, uint32_t out)
@@ -237,9 +228,8 @@ static uint32_t MAIN_MPU_331(uint32_t port, uint32_t val, uint32_t out)
   }
 #endif
   if (out) {
-    if (main_hw_mpuport) {
-      hw_mpu_outb(1, (unsigned char)(val & 0xff));
-    }
+    if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_write)
+      mpu401_aui.card_handler->card_mpu401_write(&mpu401_aui, 1, (uint8_t)(val & 0xff));
     if (val == 0xff) { // Reset
 #if MPU_DEBUG
       mpu_dbg_ctr = 0;
@@ -253,10 +243,8 @@ static uint32_t MAIN_MPU_331(uint32_t port, uint32_t val, uint32_t out)
     }
     return 0;
   }
-  if (main_hw_mpuport) {
-    uint8_t hwval = hw_mpu_inb(1);
-    return hwval;
-  }
+  if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_read)
+    return mpu401_aui.card_handler->card_mpu401_read(&mpu401_aui, 1);
   if ((mpu_state & 3) == 0) {
     return 0x80;
   } else {
@@ -276,6 +264,14 @@ static QEMM_IODT MAIN_OPL3IODT[4] =
     0x389, &MAIN_OPL3_389,
     0x38A, &MAIN_OPL3_38A,
     0x38B, &MAIN_OPL3_38B
+};
+
+static QEMM_IODT MAIN_HW_OPL3IODT[4] =
+{
+    0x388, &MAIN_HW_OPL3_388,
+    0x389, &MAIN_HW_OPL3_389,
+    0x38A, &MAIN_HW_OPL3_38A,
+    0x38B, &MAIN_HW_OPL3_38B
 };
 
 static QEMM_IODT MAIN_VDMA_IODT[40] =
@@ -395,10 +391,12 @@ struct MAIN_OPT
     "/K", "Internal sample rate (default 22050)", 22050, 0,
     "/FIXTC", "Fix time constant to match 11/22/44 kHz sample rate", FALSE, 0,
     "/SCL", "List installed sound cards", 0, MAIN_SETCMD_HIDDEN,
+    "/SCFM", "Select FM(OPL) sound card index in list (/SCL)", 0, MAIN_SETCMD_HIDDEN,
+    "/SCMPU", "Select MPU-401 sound card index in list (/SCL)", 0, MAIN_SETCMD_HIDDEN,
     "/SC", "Select sound card index in list (/SCL)", 0, MAIN_SETCMD_HIDDEN,
     "/R", "Reset sound card driver", 0, MAIN_SETCMD_HIDDEN,
     "/P", "UART mode MPU-401 IO address (default 330) [*]", 0x330, 0,
-    "/MCOM", "UART mode MPU-401 COM port (1=COM1, 2=COM2, 3=COM3, 4=COM4, 9:HW MPU only, otherwise base address)", 0, 0,
+    "/MCOM", "UART mode MPU-401 COM port (1=COM1, 2=COM2, 3=COM3, 4=COM4, 9:HW MPU only, otherwise base address)", 9, 0,
     "/COML", "List installed COM ports", 0, MAIN_SETCMD_HIDDEN,
 #if MPU_DEBUG
     "/MDBG", "Enable MPU-401 debugging (0 to disable, 1 or 2 to enable)", 0, 0,
@@ -572,7 +570,7 @@ static void MAIN_Cleanup()
     if(OldRoutedHandle.valid)
         HDPMIPT_InstallIRQRoutedHandlerH(aui.card_irq, &OldRoutedHandle);
     AU_stop(&aui);
-    AU_close(&aui);
+    AU_close(&aui, &fm_aui, &mpu401_aui);
     if(OPLRMInstalled)
         QEMM_Uninstall_IOPortTrap(&OPL3IOPT);
     if(OPLPMInstalled)
@@ -764,10 +762,14 @@ int main(int argc, char* argv[])
 
     if(MAIN_Options[OPT_SCLIST].value)
         aui.card_controlbits |= AUINFOS_CARDCNTRLBIT_TESTCARD; //note: this bit will make aui.card_handler == NULL and quit.
+    if(MAIN_Options[OPT_SCFM].value)
+        aui.card_select_index_fm = MAIN_Options[OPT_SCFM].value;
+    if(MAIN_Options[OPT_SCMPU].value)
+        aui.card_select_index_mpu401 = MAIN_Options[OPT_SCMPU].value;
     if(MAIN_Options[OPT_SC].value)
-        aui.card_select_index = MAIN_Options[OPT_SC].value; //TODO: this is a HEX in commandline, it's OK to not inform user since there's might not be over 10 (0xA) sound cards installed
+        aui.card_select_index = MAIN_Options[OPT_SC].value;
     aui.card_select_config = MAIN_Options[OPT_OUTPUT].value;
-    AU_init(&aui);
+    AU_init(&aui, &fm_aui, &mpu401_aui);
     if(!aui.card_handler)
         return 1;
     atexit(&MAIN_Cleanup);
@@ -831,20 +833,25 @@ int main(int argc, char* argv[])
 
     if(MAIN_Options[OPT_OPL].value)
     {
-        if(enableRM && !(OPLRMInstalled=QEMM_Install_IOPortTrap(MAIN_OPL3IODT, 4, &OPL3IOPT)))
+        QEMM_IODT *iodt = fm_aui.fm ? MAIN_HW_OPL3IODT : MAIN_OPL3IODT;
+        if(enableRM && !(OPLRMInstalled=QEMM_Install_IOPortTrap(iodt, 4, &OPL3IOPT)))
         {
             printf("Error: Failed installing IO port trap for QEMM.\n");
             return 1;
         }
-        if(enablePM && !(OPLPMInstalled=HDPMIPT_Install_IOPortTrap(0x388, 0x38B, MAIN_OPL3IODT, 4, &OPL3IOPT_PM)))
+        if(enablePM && !(OPLPMInstalled=HDPMIPT_Install_IOPortTrap(0x388, 0x38B, iodt, 4, &OPL3IOPT_PM)))
         {
             printf("Error: Failed installing IO port trap for HDPMI.\n");
             return 1;          
         }
 
         //OPL3EMU_Init(aui.freq_card);
-        char *emutype = (main_hw_fmport != 0) ? "hardware" : "emulation";
-        printf("OPL3 %s at port 388: ", emutype);
+        char *emutype = fm_aui.fm ? "hardware" : "emulation";
+        char hwdesc[64];
+        hwdesc[0] = '\0';
+        if (fm_aui.fm)
+          sprintf(hwdesc, "(%d:%s)", fm_aui.card_test_index, fm_aui.card_handler->shortname);
+        printf("OPL3 %s%s at port 388: ", emutype, hwdesc);
         MAIN_Print_Enabled_Newline(true);
     }
     
@@ -862,9 +869,13 @@ int main(int argc, char* argv[])
             return 1;
         }
 
-        char *emutype = (main_hw_mpuport != 0) ? "hardware" : "emulation";
-        printf("MPU-401 UART %s at address %x: ",
-               emutype, MAIN_Options[OPT_MPUADDR].value);
+        char *emutype = mpu401_aui.mpu401 ? "hardware" : "emulation";
+        char hwdesc[64];
+        hwdesc[0] = '\0';
+        if (mpu401_aui.mpu401)
+          sprintf(hwdesc, "(%d:%s)", mpu401_aui.card_test_index, mpu401_aui.card_handler->shortname);
+        printf("MPU-401 UART %s%s at address %x: ",
+               emutype, hwdesc, MAIN_Options[OPT_MPUADDR].value);
         MAIN_Print_Enabled_Newline(true);
     }
 
@@ -889,11 +900,18 @@ int main(int argc, char* argv[])
     QEMM_IODT* SB_Iodt = MAIN_Options[OPT_OPL].value ? MAIN_SB_IODT : MAIN_SB_IODT+4;
     int SB_IodtCount = MAIN_Options[OPT_OPL].value ? countof(MAIN_SB_IODT) : countof(MAIN_SB_IODT)-4;
 
-    printf("SB %s emulation at address %x, IRQ %x, DMA %x: ",
-            MAIN_SBTypeString[MAIN_Options[OPT_TYPE].value],
-            MAIN_Options[OPT_ADDR].value,
-            MAIN_Options[OPT_IRQ].value,
-            MAIN_Options[OPT_DMA].value);
+    {
+      char hwdesc[64];
+      hwdesc[0] = '\0';
+      if (aui.pcm)
+        sprintf(hwdesc, "(%d:%s)", aui.card_test_index, aui.card_handler->shortname);
+      printf("SB %s%s emulation at address %x, IRQ %x, DMA %x: ",
+             MAIN_SBTypeString[MAIN_Options[OPT_TYPE].value],
+             hwdesc,
+             MAIN_Options[OPT_ADDR].value,
+             MAIN_Options[OPT_IRQ].value,
+             MAIN_Options[OPT_DMA].value);
+    }
     MAIN_Print_Enabled_Newline(true);
 
     BOOL QEMMInstalledVDMA = !enableRM || QEMM_Install_IOPortTrap(MAIN_VDMA_IODT, countof(MAIN_VDMA_IODT), &MAIN_VDMA_IOPT);
@@ -1453,12 +1471,14 @@ static void MAIN_TSR_Interrupt()
                 if(opt[OPT_OUTPUT].value != MAIN_Options[OPT_OUTPUT].value || opt[OPT_RESET].value)
                 {
                     _LOG("Reset\n");
-                    AU_close(&aui);
+                    AU_close(&aui, &fm_aui, &mpu401_aui);
                     memset(&aui, 0, sizeof(aui));
+                    memset(&fm_aui, 0, sizeof(fm_aui));
+                    memset(&mpu401_aui, 0, sizeof(mpu401_aui));
                     aui.card_select_config = MAIN_Options[OPT_OUTPUT].value = opt[OPT_OUTPUT].value;
                     aui.card_select_index =  MAIN_Options[OPT_SC].value;
                     aui.card_controlbits |= AUINFOS_CARDCNTRLBIT_SILENT; //don't print anything in interrupt
-                    AU_init(&aui);
+                    AU_init(&aui, &fm_aui, &mpu401_aui);
                     AU_ini_interrupts(&aui);
                     AU_setmixer_init(&aui);
                     AU_setmixer_outs(&aui, MIXER_SETMODE_ABSOLUTE, 100);
@@ -1562,8 +1582,9 @@ static void MAIN_TSR_Interrupt()
             if(opt[OPT_OPL].value)
             {
                 _LOG("install opl\n");
-                if(opt[OPT_RM].value) QEMM_Install_IOPortTrap(MAIN_OPL3IODT, 4, &OPL3IOPT);
-                if(opt[OPT_PM].value) HDPMIPT_Install_IOPortTrap(0x388, 0x38B, MAIN_OPL3IODT, 4, &OPL3IOPT_PM);
+                QEMM_IODT *iodt = fm_aui.fm ? MAIN_HW_OPL3IODT : MAIN_OPL3IODT;
+                if(opt[OPT_RM].value) QEMM_Install_IOPortTrap(iodt, 4, &OPL3IOPT);
+                if(opt[OPT_PM].value) HDPMIPT_Install_IOPortTrap(0x388, 0x38B, iodt, 4, &OPL3IOPT_PM);
             }
 
             if(opt[OPT_MPUADDR].value && opt[OPT_MPUCOMPORT].value)

--- a/main.c
+++ b/main.c
@@ -380,7 +380,7 @@ struct MAIN_OPT
     "/DBG", "Debug output (0=console, 1=COM1, 2=COM2, 3=COM3, 4=COM4, otherwise base address)", 0, 0,
 
     "/A", "IO address (220 or 240) [*]", 0x220, 0,
-    "/I", "IRQ number (5 or 7) [*]", 7, 0,
+    "/I", "IRQ number (5 or 7 or 9) [*]", 7, 0,
     "/D", "8-bit DMA channel (0, 1 or 3) [*]", 1, 0,
     "/T", "SB Type (1, 2 or 3=SB; 4 or 5=SBPro; 6=SB16) [*]", 5, 0,
     "/H", "16-bit (\"high\") DMA channel (5, 6 or 7) [*]", 5, 0,
@@ -662,7 +662,7 @@ int main(int argc, char* argv[])
         printf("Error: Invalid IO port address: %x.\n", MAIN_Options[OPT_ADDR].value);
         return 1;
     }
-    if(MAIN_Options[OPT_IRQ].value != 0x5 && MAIN_Options[OPT_IRQ].value != 0x7)
+    if(MAIN_Options[OPT_IRQ].value != 0x5 && MAIN_Options[OPT_IRQ].value != 0x7 && MAIN_Options[OPT_IRQ].value != 0x9)
     {
         printf("Error: invalid IRQ: %d.\n", MAIN_Options[OPT_IRQ].value);
         return 1;

--- a/main.c
+++ b/main.c
@@ -392,7 +392,7 @@ struct MAIN_OPT
     "/O", "Select output. 0: headphone, 1: speaker. Intel HDA only", 1, 0,
     "/VOL", "Set master volume (0-9)", 7, 0,
 
-    "/K", "Internal sample rate (22050 or 44100)", 0x22050, 0,
+    "/K", "Internal sample rate (default 22050)", 22050, 0,
     "/FIXTC", "Fix time constant to match 11/22/44 kHz sample rate", FALSE, 0,
     "/SCL", "List installed sound cards", 0, MAIN_SETCMD_HIDDEN,
     "/SC", "Select sound card index in list (/SCL)", 0, MAIN_SETCMD_HIDDEN,
@@ -706,7 +706,7 @@ int main(int argc, char* argv[])
         printf("Error: Invalid Volume.\n");
         return 1;
     }
-    if(MAIN_Options[OPT_RATE].value != 0x22050 && MAIN_Options[OPT_RATE].value != 0x44100)
+    if(MAIN_Options[OPT_RATE].value < 4000 || MAIN_Options[OPT_RATE].value > 192000)
     {
         printf("Error: Invalid Sample rate.\n");
         return 1;

--- a/makefile
+++ b/makefile
@@ -7,8 +7,8 @@ VERSION ?= $(shell git describe --tags)
 
 INCLUDES := -I./mpxplay -I./sbemu
 DEFINES := -D__DOS__ -DSBEMU -DDEBUG=$(DEBUG) -DMAIN_SBEMU_VER=\"$(VERSION)\"
-CFLAGS := -fcommon -march=i386 -O2 -flto=auto -Wno-attributes $(INCLUDES) $(DEFINES)
-LDFLAGS := -lstdc++ -lm -save-temps
+CFLAGS := -fcommon -march=i386 -Os -flto=auto -Wno-attributes $(INCLUDES) $(DEFINES)
+LDFLAGS := -lstdc++ -lm
 
 ifeq ($(DEBUG),0)
 LDFLAGS += -s
@@ -34,6 +34,7 @@ CARDS_SRC := mpxplay/au_cards/ac97_def.c \
 	     mpxplay/au_cards/au_cards.c \
 	     mpxplay/au_cards/dmairq.c \
 	     mpxplay/au_cards/pcibios.c \
+	     mpxplay/au_cards/ioport.c \
 	     mpxplay/au_cards/sc_e1371.c \
 	     mpxplay/au_cards/sc_ich.c \
 	     mpxplay/au_cards/sc_cmi.c \

--- a/mpxplay/au_cards/au_cards.h
+++ b/mpxplay/au_cards/au_cards.h
@@ -228,18 +228,25 @@ typedef struct mpxplay_audioout_info_s{
 
  char *card_selectname;          // select card by name - NOT used by SBEMU
  #ifdef SBEMU
- int card_test_index;       //tmp curret test index
- int card_select_index;     //user selection via cmd line
+ int card_test_index;            //current test index for main card
+ int card_select_index;          //user selection for main card
+ int card_select_index_fm;       //user selection for FM(OPL) card
+ int card_select_index_mpu401;   //user selection via MPU-401 card
  int card_samples_per_int;  //samples per interrupt
  struct pci_config_s* card_pci_dev;
+ uint16_t fm_port;
+ uint16_t mpu401_port;
+ unsigned int pcm: 1, fm: 1, mpu401: 1;
  #endif
  struct one_sndcard_info *card_handler; // function structure of the card
  void *card_private_data;        // extra private datas can be pointed here (with malloc)
+ unsigned char  card_irq;
+#ifndef SBEMU
  unsigned short card_type;
  unsigned short card_port;
- unsigned char  card_irq;
  unsigned char  card_isa_dma;
  unsigned char  card_isa_hidma;
+#endif
 
  struct mainvars *mvp;
  struct playlist_entry_info *pei; // for encoders
@@ -270,10 +277,15 @@ typedef struct one_sndcard_info{
  void (*card_writemixer)(struct mpxplay_audioout_info_s *,unsigned long mixreg,unsigned long value);
  unsigned long (*card_readmixer)(struct mpxplay_audioout_info_s *,unsigned long mixreg);
  aucards_allmixerchan_s *card_mixerchans;
+
+ void (*card_fm_write)(struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data);
+ uint8_t (*card_fm_read)(struct mpxplay_audioout_info_s *aui, unsigned int idx);
+ void (*card_mpu401_write)(struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data);
+ uint8_t (*card_mpu401_read)(struct mpxplay_audioout_info_s *aui, unsigned int idx);
 }one_sndcard_info;
 
 //main soundcard routines
-extern void AU_init(struct mpxplay_audioout_info_s *aui);
+extern void AU_init(struct mpxplay_audioout_info_s *aui,struct mpxplay_audioout_info_s *fm_aui,struct mpxplay_audioout_info_s *mpu401_aui);
 extern void AU_ini_interrupts(struct mpxplay_audioout_info_s *);
 extern void AU_del_interrupts(struct mpxplay_audioout_info_s *aui);
 extern void AU_prestart(struct mpxplay_audioout_info_s *);
@@ -282,7 +294,7 @@ extern void AU_wait_and_stop(struct mpxplay_audioout_info_s *);
 extern void AU_stop(struct mpxplay_audioout_info_s *);
 extern void AU_suspend_decoding(struct mpxplay_audioout_info_s *aui);
 extern void AU_resume_decoding(struct mpxplay_audioout_info_s *aui);
-extern void AU_close(struct mpxplay_audioout_info_s *);
+extern void AU_close(struct mpxplay_audioout_info_s *aui,struct mpxplay_audioout_info_s *fm_aui,struct mpxplay_audioout_info_s *mpu401_aui);
 extern void AU_setrate(struct mpxplay_audioout_info_s *aui,struct mpxplay_audio_decoder_info_s *adi);
 extern void AU_setmixer_init(struct mpxplay_audioout_info_s *aui);
 extern void AU_setmixer_one(struct mpxplay_audioout_info_s *,unsigned int mixch,unsigned int setmode,int value);
@@ -297,6 +309,10 @@ extern int  AU_writedata(struct mpxplay_audioout_info_s *);
 
 #ifdef SBEMU
 extern unsigned char au_cards_fallback_to_null;
+extern uint8_t ioport_fm_read (struct mpxplay_audioout_info_s *aui, unsigned int idx);
+extern void ioport_fm_write (struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data);
+extern uint8_t ioport_mpu401_read (struct mpxplay_audioout_info_s *aui, unsigned int idx);
+extern void ioport_mpu401_write (struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data);
 #endif
 
 #ifdef __cplusplus

--- a/mpxplay/au_cards/dmairq.c
+++ b/mpxplay/au_cards/dmairq.c
@@ -213,7 +213,7 @@ void MDma_interrupt_monitor(struct mpxplay_audioout_info_s *aui)
 
 //------------------------------------------------------------------------
 //ISA
-#ifdef AU_CARDS_LINK_ISA
+#if defined(AU_CARDS_LINK_ISA) && !defined(SBEMU)
 
 #define MDMA_ISA_DMABUFSIZE_MAX 65535
 #define MDMA_ISA_BLOCKSIZE       4608 // PCM_OUTSAMPLES*2*2  (4608%256==0 for GUS!)

--- a/mpxplay/au_cards/ioport.c
+++ b/mpxplay/au_cards/ioport.c
@@ -1,0 +1,27 @@
+#include "au_cards.h"
+
+#define hw_fm_outb(reg,data) outp(aui->fm_port+reg,data)
+#define hw_fm_inb(reg) inp(aui->fm_port+reg)
+
+uint8_t ioport_fm_read (struct mpxplay_audioout_info_s *aui, unsigned int idx)
+{
+  return hw_fm_inb(idx);
+}
+
+void ioport_fm_write (struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data)
+{
+  hw_fm_outb(idx, data);
+}
+
+#define hw_mpu_outb(reg,data) outp(aui->mpu401_port+reg,data)
+#define hw_mpu_inb(reg) inp(aui->mpu401_port+reg)
+
+uint8_t ioport_mpu401_read (struct mpxplay_audioout_info_s *aui, unsigned int idx)
+{
+  return hw_mpu_inb(idx);
+}
+
+void ioport_mpu401_write (struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data)
+{
+  hw_mpu_outb(idx, data);
+}

--- a/mpxplay/au_cards/sc_null.c
+++ b/mpxplay/au_cards/sc_null.c
@@ -18,13 +18,11 @@
 
 static int NUL_init(struct mpxplay_audioout_info_s *aui)
 {
- aui->card_port=aui->card_isa_dma=aui->card_irq=aui->card_isa_hidma=aui->card_type=0;
  return 1;
 }
 
 static int NUL_detect(struct mpxplay_audioout_info_s *aui)
 {
- aui->card_port=aui->card_isa_dma=aui->card_irq=aui->card_isa_hidma=aui->card_type=0;
  return 1;
 }
 


### PR DESCRIPTION
It will print which card is being used, like this:
OPL3 hardware(2:ALS4000) at port 388: enabled.
MPU-401 UART hardware(1:YMF) at address 330: enabled.
SB Pro(3:TRIDENT) emulation at address 220, IRQ 7, DMA 1: enabled.

*ALS4000 and Trident drivers are not included in this.

The /MCOM option default is now 9: hardware only (no serial output)
Other changes:
[Allow IRQ 9 with /I option] (I have a motherboard that can reserve IRQ numbers only from 9 on up)
[Base 10 option support]  (Used for /SC* options and /K option)
[Allow arbitrary sample rate between 4KHz and 192KHz with the /K option] (Good for testing)

Also, like I mentioned in #84 I removed -O2 and -save-temps from CFLAGS/LDFLAGS