### PR TITLE
Squash compiler warnings + CMI8738 hardware FM & MPU-401

### DIFF
--- a/main.c
+++ b/main.c
@@ -85,10 +85,11 @@ static void MAIN_TSR_Interrupt();
       }                                                                 \
     } else {                                                            \
       if (fm_aui.card_handler->card_fm_read)                            \
-        return fm_aui.card_handler->card_fm_read(&fm_aui, n);              \
+        return fm_aui.card_handler->card_fm_read(&fm_aui, n);           \
     }                                                                   \
-    return 0;                                                           \
-  } } while (0)
+  }                                                                     \
+  return 0;                                                             \
+  } while (0)
 
 static uint32_t MAIN_OPL3_388(uint32_t port, uint32_t val, uint32_t out)
 {
@@ -765,7 +766,7 @@ int main(int argc, char* argv[])
     {
         printf("Invalid Sound card IRQ: ");
         MAIN_CPrintf(RED, "%d", aui.card_irq);
-        printf(", Trying to assign a valid IRQ...\n", aui.card_irq);
+        printf(", Trying to assign a valid IRQ...\n");
         aui.card_irq = pcibios_AssignIRQ(aui.card_pci_dev);
         if(aui.card_irq == 0xFF)
         {

--- a/main.c
+++ b/main.c
@@ -196,9 +196,12 @@ static uint32_t MAIN_MPU_330(uint32_t port, uint32_t val, uint32_t out)
     ser_putbyte((int)(val & 0xff));
     return 0;
   } else {
-    uint8_t val, hwval;
-    if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_read)
+    uint8_t val, hwval, hwval_valid = 0;
+    if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_read) {
       hwval = mpu401_aui.card_handler->card_mpu401_read(&mpu401_aui, 0);
+      if (!mpu401_aui.mpu401_softread)
+        hwval_valid = 1;
+    }
     if (mpu_state == 1) {
       mpu_state = 0;
       val = 0xfe;
@@ -208,7 +211,7 @@ static uint32_t MAIN_MPU_330(uint32_t port, uint32_t val, uint32_t out)
     } else {
       val = 0;
     }
-    if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_read)
+    if (hwval_valid)
       return hwval;
     else
       return val;
@@ -244,8 +247,11 @@ static uint32_t MAIN_MPU_331(uint32_t port, uint32_t val, uint32_t out)
     }
     return 0;
   }
-  if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_read)
-    return mpu401_aui.card_handler->card_mpu401_read(&mpu401_aui, 1);
+  if (mpu401_aui.mpu401 && mpu401_aui.card_handler->card_mpu401_read) {
+    uint8_t hwval = mpu401_aui.card_handler->card_mpu401_read(&mpu401_aui, 1);
+    if (!mpu401_aui.mpu401_softread)
+      return hwval;
+  }
   if ((mpu_state & 3) == 0) {
     return 0x80;
   } else {

--- a/mpxplay/au_cards/au_base.c
+++ b/mpxplay/au_cards/au_base.c
@@ -331,9 +331,11 @@ int pds_dpmi_xms_allocmem(xmsmem_t * mem,unsigned int size)
                 unsigned long newlimit = info.address + size - base - 1;
                 newlimit = ((newlimit+1+0xFFF)&~0xFFF) - 1;//__dpmi_set_segment_limit must be page aligned
                 //printf("addr: %08x, limit: %08x\n",mem->linearptr, newlimit);
+                int intr = disable();
                 __dpmi_set_segment_limit(_my_ds(), max(limit, newlimit));
                 __dpmi_set_segment_limit(__djgpp_ds_alias, max(limit, newlimit));
                 __djgpp_selector_limit = max(limit, newlimit);
+                if (intr) enable();
                 return 1;
             }
         }while(0);

--- a/mpxplay/au_cards/au_cards.h
+++ b/mpxplay/au_cards/au_cards.h
@@ -228,10 +228,10 @@ typedef struct mpxplay_audioout_info_s{
 
  char *card_selectname;          // select card by name - NOT used by SBEMU
  #ifdef SBEMU
- int card_test_index;            //current test index for main card
+ int card_test_index;            //current test index
  int card_select_index;          //user selection for main card
  int card_select_index_fm;       //user selection for FM(OPL) card
- int card_select_index_mpu401;   //user selection via MPU-401 card
+ int card_select_index_mpu401;   //user selection for MPU-401 card
  int card_samples_per_int;  //samples per interrupt
  struct pci_config_s* card_pci_dev;
  uint16_t fm_port;

--- a/mpxplay/au_cards/au_cards.h
+++ b/mpxplay/au_cards/au_cards.h
@@ -236,7 +236,7 @@ typedef struct mpxplay_audioout_info_s{
  struct pci_config_s* card_pci_dev;
  uint16_t fm_port;
  uint16_t mpu401_port;
- unsigned int pcm: 1, fm: 1, mpu401: 1;
+ unsigned int pcm: 1, fm: 1, mpu401: 1, mpu401_softread;
  #endif
  struct one_sndcard_info *card_handler; // function structure of the card
  void *card_private_data;        // extra private datas can be pointed here (with malloc)

--- a/mpxplay/au_cards/ioport.c
+++ b/mpxplay/au_cards/ioport.c
@@ -23,7 +23,8 @@ uint8_t ioport_mpu401_read (struct mpxplay_audioout_info_s *aui, unsigned int id
 
 void ioport_mpu401_write (struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data)
 {
-  if (idx == 0) {
+#if 0 // shouldn't DOS programs be doing this themselves if it was really necessary?
+  if (idx == 0 && aui->) {
     int timeout = 10000; // 100ms
     do {
       uint8_t st = hw_mpu_inb(1);
@@ -32,5 +33,6 @@ void ioport_mpu401_write (struct mpxplay_audioout_info_s *aui, unsigned int idx,
       pds_delay_10us(1);
     } while (--timeout);
   }
+#endif
   hw_mpu_outb(idx, data);
 }

--- a/mpxplay/au_cards/ioport.c
+++ b/mpxplay/au_cards/ioport.c
@@ -23,5 +23,14 @@ uint8_t ioport_mpu401_read (struct mpxplay_audioout_info_s *aui, unsigned int id
 
 void ioport_mpu401_write (struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data)
 {
+  if (idx == 0) {
+    int timeout = 10000; // 100ms
+    do {
+      uint8_t st = hw_mpu_inb(1);
+      if (!(st & 0x40)) break;
+      // still full
+      pds_delay_10us(1);
+    } while (--timeout);
+  }
   hw_mpu_outb(idx, data);
 }

--- a/mpxplay/au_cards/ioport.c
+++ b/mpxplay/au_cards/ioport.c
@@ -24,7 +24,7 @@ uint8_t ioport_mpu401_read (struct mpxplay_audioout_info_s *aui, unsigned int id
 void ioport_mpu401_write (struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data)
 {
 #if 0 // shouldn't DOS programs be doing this themselves if it was really necessary?
-  if (idx == 0 && aui->) {
+  if (idx == 0 && aui->mpu401_softread) {
     int timeout = 10000; // 100ms
     do {
       uint8_t st = hw_mpu_inb(1);

--- a/mpxplay/au_cards/pcibios.c
+++ b/mpxplay/au_cards/pcibios.c
@@ -715,7 +715,7 @@ uint8_t  pcibios_AssignIRQ(pci_config_s* ppkey)
                     if(intpin-1 == j)
                     {
                         linkedIRQ = pcibios_ReadConfig_Byte(&cfg, PCIR_INTR_LN);
-                        assert(linkedIRQ == 0xFF || ((1<<linkedIRQ)&&table[i].intpins[j].map) != 0);
+                        assert(linkedIRQ == 0xFF || ((1<<linkedIRQ)&table[i].intpins[j].map) != 0);
                         if(linkedIRQ != 0xFF)
                         {
                             _LOG("Found shared IRQ: %d, pin: INT%c# on bdf %d %d %d\n", linkedIRQ, 'A'+j, cfg.bBus, cfg.bDev, cfg.bFunc);

--- a/mpxplay/au_cards/sc_cmi.c
+++ b/mpxplay/au_cards/sc_cmi.c
@@ -921,8 +921,8 @@ static int CMI8X38_IRQRoutine(mpxplay_audioout_info_s* aui)
   cmi8x38_card *card=aui->card_private_data;
   int status = snd_cmipci_read_32(card, CM_REG_INT_STATUS); //read only reg (R)
   while(status == -1) snd_cmipci_read_32(card, CM_REG_INT_STATUS);
-  if ( card->chip_version > 37 && !(status&CM_INTR) ||
-      card->chip_version <= 37 && !(status & CM_INTR_MASK)) { //the summary bit is incorrect for PCI-SX, the interrupt be chained to other shared IRQ device with invalid interrupts
+  if ((card->chip_version > 37 && !(status&CM_INTR)) ||
+      (card->chip_version <= 37 && !(status & CM_INTR_MASK))) { //the summary bit is incorrect for PCI-SX, the interrupt be chained to other shared IRQ device with invalid interrupts
     return 0;
   }
   if(status&CM_MCBINT) //Abort conditions occur during PCI Bus Target/Master Access

--- a/mpxplay/au_cards/sc_cmi.c
+++ b/mpxplay/au_cards/sc_cmi.c
@@ -1013,7 +1013,6 @@ static aucards_allmixerchan_s cmi8x38_mixerset[]={
  NULL
 };
 
-#if 0 // use ioport_mpu401_write
 static void cmi8x38_mpu401_write (struct mpxplay_audioout_info_s *aui, unsigned int idx, uint8_t data)
 {
   if (idx == 0) {
@@ -1027,7 +1026,6 @@ static void cmi8x38_mpu401_write (struct mpxplay_audioout_info_s *aui, unsigned 
   }
   outp(aui->mpu401_port+idx, data);
 }
-#endif
 
 static uint8_t cmi8x38_mpu401_read (struct mpxplay_audioout_info_s *aui, unsigned int idx)
 {
@@ -1074,8 +1072,7 @@ one_sndcard_info CMI8X38_sndcard_info={
 
  &ioport_fm_write,
  &ioport_fm_read,
- //&cmi8x38_mpu401_write,
- &ioport_mpu401_write,
+ &cmi8x38_mpu401_write,
  &cmi8x38_mpu401_read,
 };
 

--- a/mpxplay/au_cards/sc_ymf.c
+++ b/mpxplay/au_cards/sc_ymf.c
@@ -869,10 +869,10 @@ static int snd_ymfpci_memalloc (struct mpxplay_audioout_info_s *aui)
     return -1;
 
   memset(card->dm->linearptr, 0, size);
-  ptr = card->dm->linearptr;
+  ptr = (uint8_t *)card->dm->linearptr;
   ptr_addr = (dma_addr_t)ptr;
 
-  ptr = (char *)ALIGN((unsigned long)ptr, 0x100);
+  ptr = (uint8_t *)ALIGN((unsigned long)ptr, 0x100);
   ptr_addr = ALIGN(ptr_addr, 0x100);
 
   card->bank_base_playback = ptr;
@@ -892,7 +892,7 @@ static int snd_ymfpci_memalloc (struct mpxplay_audioout_info_s *aui)
       ptr_addr += card->bank_size_playback;
     }
   }
-  ptr = (char *)ALIGN((unsigned long)ptr, 0x100);
+  ptr = (uint8_t *)ALIGN((unsigned long)ptr, 0x100);
   ptr_addr = ALIGN(ptr_addr, 0x100);
   card->bank_base_capture = ptr;
   card->bank_base_capture_addr = (uint32_t)pds_cardmem_physicalptr(card->dm, ptr_addr);
@@ -903,7 +903,7 @@ static int snd_ymfpci_memalloc (struct mpxplay_audioout_info_s *aui)
       ptr_addr += card->bank_size_capture;
     }
   }
-  ptr = (char *)ALIGN((unsigned long)ptr, 0x100);
+  ptr = (uint8_t *)ALIGN((unsigned long)ptr, 0x100);
   ptr_addr = ALIGN(ptr_addr, 0x100);
   card->bank_base_effect = ptr;
   card->bank_base_effect_addr = (uint32_t)pds_cardmem_physicalptr(card->dm, ptr_addr);
@@ -914,14 +914,14 @@ static int snd_ymfpci_memalloc (struct mpxplay_audioout_info_s *aui)
       ptr_addr += card->bank_size_effect;
     }
   }
-  ptr = (char *)ALIGN((unsigned long)ptr, 0x100);
+  ptr = (uint8_t *)ALIGN((unsigned long)ptr, 0x100);
   ptr_addr = ALIGN(ptr_addr, 0x100);
   card->work_base = ptr;
   card->work_base_addr = (uint32_t)pds_cardmem_physicalptr(card->dm, ptr_addr);
 
   card->pcmout_buffer = card->work_base + card->work_size;
   card->pcmout_buffer_physaddr = (uint32_t)pds_cardmem_physicalptr(card->dm, card->pcmout_buffer);
-  aui->card_DMABUFF = card->pcmout_buffer;
+  aui->card_DMABUFF = (char *)card->pcmout_buffer;
 
 #if YMF_DEBUG
   DBG_Logi("playback base: %8.8X\n", card->bank_base_playback_addr);


### PR DESCRIPTION
Please check if the fixes in pcibios.c and sc_cmi.c are correct

```
--- a/mpxplay/au_cards/sc_cmi.c
+++ b/mpxplay/au_cards/sc_cmi.c
@@ -921,8 +921,8 @@ static int CMI8X38_IRQRoutine(mpxplay_audioout_info_s* aui)
   cmi8x38_card *card=aui->card_private_data;
   int status = snd_cmipci_read_32(card, CM_REG_INT_STATUS); //read only reg (R)
   while(status == -1) snd_cmipci_read_32(card, CM_REG_INT_STATUS);
-  if ( card->chip_version > 37 && !(status&CM_INTR) ||
-      card->chip_version <= 37 && !(status & CM_INTR_MASK)) { //the summary bit is incorrect for PCI-SX, the interrupt be chained to other shared IRQ device with invalid interrupts
+  if ((card->chip_version > 37 && !(status&CM_INTR)) ||
+      (card->chip_version <= 37 && !(status & CM_INTR_MASK))) { //the summary bit is incorrect for PCI-SX, the interrupt be chained to other shared IRQ device with invalid interrupts
     return 0;
   }
   if(status&CM_MCBINT) //Abort conditions occur during PCI Bus Target/Master Access
```

```
--- a/mpxplay/au_cards/pcibios.c
+++ b/mpxplay/au_cards/pcibios.c
@@ -715,7 +715,7 @@ uint8_t  pcibios_AssignIRQ(pci_config_s* ppkey)
                     if(intpin-1 == j)
                     {
                         linkedIRQ = pcibios_ReadConfig_Byte(&cfg, PCIR_INTR_LN);
-                        assert(linkedIRQ == 0xFF || ((1<<linkedIRQ)&&table[i].intpins[j].map) != 0);
+                        assert(linkedIRQ == 0xFF || ((1<<linkedIRQ)&table[i].intpins[j].map) != 0);
                         if(linkedIRQ != 0xFF)
                         {
                             _LOG("Found shared IRQ: %d, pin: INT%c# on bdf %d %d %d\n", linkedIRQ, 'A'+j, cfg.bBus, cfg.bDev, cfg.bFunc);
```