### PR TITLE
Feature/add ess maestro

### DIFF
--- a/drivers/maestro3/maestro3.c
+++ b/drivers/maestro3/maestro3.c
@@ -1241,21 +1241,22 @@ struct ac97_initial_values {
   uint16_t value;
 };
 
+// Source: AC97 specs, https://www.alsa-project.org/files/pub/datasheets/intel/ac97r21.pdf, 6.3 Mixer Registers
 static struct ac97_initial_values ac97_initial_values[] = {
     { AC97_RESET,           0x0000 },
     { AC97_MASTER,          0x0808 },
     { AC97_HEADPHONE,       0x0808 },
     { AC97_PCM,             0x0808 },
-    { AC97_MASTER_MONO,     0x0000 },
+    { AC97_MASTER_MONO,     0x8000 },
     { AC97_PC_BEEP,         0x0000 },
-    { AC97_PHONE,           0x0008 },
-    { AC97_MIC,             0x0505 },
-    { AC97_LINE,            0x0505 },
-    { AC97_CD,              0x0505 },
-    { AC97_VIDEO,           0x0000 },
-    { AC97_AUX,             0x0000 },
+    { AC97_PHONE,           0x8008 },
+    { AC97_MIC,             0x8008 },
+    { AC97_LINE,            0x8808 },
+    { AC97_CD,              0x8808 },
+    { AC97_VIDEO,           0x8808 },
+    { AC97_AUX,             0x8808 },
     { AC97_REC_SEL,         0x0000 },
-    { AC97_REC_GAIN,        0x0B0B },
+    { AC97_REC_GAIN,        0x8000 },
     { AC97_GENERAL_PURPOSE, 0x0000 },
     //{ AC97_EXTENDED_STATUS, AC97_EA_SPDIF },
     { AC97_MASTER,          0x0707 },

--- a/mpxplay/au_cards/sc_allegro.c
+++ b/mpxplay/au_cards/sc_allegro.c
@@ -20,11 +20,12 @@
 
 static pci_device_s allegro_devices[] = {
   {"Allegro-1",         0x125D, 0x1988, 0}, // ES1988S/ES1989S
-  {"Maestro 1",         0x125D, 0x1948, 0}, // ES1948
+  {"Allegro",           0x125D, 0x1989, 0}, // ES1988S/ES1989S
   {"Maestro 2",         0x125D, 0x1968, 0}, // ES1968
   {"Maestro 2E",        0x125D, 0x1978, 0}, // ES1978
-  {"Solo 1 Audiodrive", 0x125D, 0x1969, 0}, // ES1938/ES1946/ES1969 Solo-1
   {"Maestro-3i",        0x125D, 0x1998, 0}, // ES1983/ES1983S
+  {"Canyon3D 2 LE",     0x125D, 0x1990, 0}, // ES1990
+  {"Canyon3D 2",        0x125D, 0x1992, 0}, // ES1992
   {NULL,0,0,0}
 };
 

--- a/mpxplay/au_cards/sc_allegro.c
+++ b/mpxplay/au_cards/sc_allegro.c
@@ -19,7 +19,12 @@
 #include "../../drivers/maestro3/maestro3.h"
 
 static pci_device_s allegro_devices[] = {
-  {"Allegro-1", 0x125D, 0x1988, 0}, // Both ES1988S and ES1989S share this ID
+  {"Allegro-1",         0x125D, 0x1988, 0}, // ES1988S/ES1989S
+  {"Maestro 1",         0x125D, 0x1948, 0}, // ES1948
+  {"Maestro 2",         0x125D, 0x1968, 0}, // ES1968
+  {"Maestro 2E",        0x125D, 0x1978, 0}, // ES1978
+  {"Solo 1 Audiodrive", 0x125D, 0x1969, 0}, // ES1938/ES1946/ES1969 Solo-1
+  {"Maestro-3i",        0x125D, 0x1998, 0}, // ES1983/ES1983S
   {NULL,0,0,0}
 };
 


### PR DESCRIPTION
This PR adds ESS Maestro 3i (ES1983) support. It also tweaks AC97 default volume settings, to mute inputs like microphone and line in by default.

Maestro 3i support is tested and working on:
Fujitsu Siemens Liteline
Dell Latitude C810 1000X
Games used: Doom, Descent, Duke3D

I've also gone ahead and added the Maestro 2, 2E, Canyon 3d 2 support. These were already part of the Linux drivers, but remain untested.