### PR TITLE
ci: Make required Git tag pattern for triggering builds and releases less strict

### DIFF
--- a/.github/workflows/01-build-and-release.yml
+++ b/.github/workflows/01-build-and-release.yml
@@ -4,7 +4,7 @@ name: build-and-release
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]*
 
 permissions:
   contents: write


### PR DESCRIPTION
Allow any tag that starts with `v` followed by a number, even if it's not SemVer compliant, such as `1.0beta5`