### PR TITLE
fix: RESETHACK for CT5880

### DIFF
--- a/mpxplay/au_cards/sc_e1371.c
+++ b/mpxplay/au_cards/sc_e1371.c
@@ -504,7 +504,7 @@ static int ES1371_adetect(struct mpxplay_audioout_info_s *aui)
   )
  ){
   funcbit_enable(card->infobits,ENSONIQ_CARD_INFOBIT_AC97RESETHACK);
-  funcbit_enable(card->sctrl,ES_1371_ST_AC97_RST);
+  funcbit_enable(card->cssr,ES_1371_ST_AC97_RST);
  }
 
  if(pcibios_search_devices(amplifier_hack_devices,NULL)==PCI_SUCCESSFUL)


### PR DESCRIPTION
Some revisions of the Ensoniq 1371 labelled CT5880 require a certain bit to be set to get the AC97 out of hard reset. These revisions are correctly identified and the RESETHACK flag is set. The certain bit that needs to be set is located in the "Chip Select and Status Register" (CSSR), not in the "Serial Interface Control Register" (SCTRL).

This commit fixes SBEMU on a mainboard with an onboard Sound Blaster PCI.

Closes #164 